### PR TITLE
Fix: Add Spring Boot 3.x autoconfiguration support

### DIFF
--- a/agent-models/spring-ai-claude-agent/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agent-models/spring-ai-claude-agent/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+org.springaicommunity.agents.claude.autoconfigure.ClaudeAgentAutoConfiguration
+org.springaicommunity.agents.claude.autoconfigure.SandboxAutoConfiguration


### PR DESCRIPTION
## Summary

- Adds Spring Boot 3.x autoconfiguration support to the `spring-ai-claude-agent` module
- Fixes compatibility issue with Spring Boot 3.5.0 applications

## Problem

When running samples with Spring Boot 3.5.0 (e.g., `getting-started-hello-world`), the application failed to start with:

```
Error creating bean with name 'demo': Unsatisfied dependency expressed through method 'demo' parameter 0: 
No qualifying bean of type 'org.springaicommunity.agents.client.AgentClient$Builder' available
```

### Root Cause

Spring Boot changed its autoconfiguration discovery mechanism in version 3.x:
- **Spring Boot 2.x**: Uses `META-INF/spring.factories`
- **Spring Boot 3.x**: Uses `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

The `spring-ai-claude-agent` module only had the Spring Boot 2.x format, causing Spring Boot 3.x to not discover `ClaudeAgentAutoConfiguration` and `SandboxAutoConfiguration`. Without these, the required beans were never created.

## Solution

Added `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` with the two autoconfiguration classes:
- `org.springaicommunity.agents.claude.autoconfigure.ClaudeAgentAutoConfiguration`
- `org.springaicommunity.agents.claude.autoconfigure.SandboxAutoConfiguration`

The existing `spring.factories` file is retained for backward compatibility with Spring Boot 2.x applications.

## Test Plan

- [ ] Verify the autoconfiguration file is included in the built jar
- [ ] Test that `getting-started-hello-world` sample starts successfully with Spring Boot 3.5.0
- [ ] Verify `AgentClient.Builder` bean is properly injected
- [ ] Confirm backward compatibility with Spring Boot 2.x (if applicable)

## Impact

- Enables Spring Boot 3.x compatibility for the Claude agent module
- No breaking changes - maintains Spring Boot 2.x compatibility
- Other agent model modules (Gemini, SWE-bench) may need similar updates