### PR TITLE
fix: correct Claude model name from claude-sonnet-4.5 to claude-sonnet-4-5

### DIFF
--- a/agent-models/spring-ai-claude-agent/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentProperties.java
+++ b/agent-models/spring-ai-claude-agent/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentProperties.java
@@ -35,7 +35,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *   ai:
  *     agents:
  *       claude-code:
- *         model: "claude-sonnet-4.5"
+ *         model: "claude-sonnet-4-5"
  *         timeout: "PT5M"
  *         yolo: true
  *         executable-path: "/usr/local/bin/claude"
@@ -50,7 +50,7 @@ public class ClaudeAgentProperties {
 	/**
 	 * Claude model to use for agent tasks.
 	 */
-	private String model = "claude-sonnet-4.5";
+	private String model = "claude-sonnet-4-5";
 
 	/**
 	 * Timeout for agent task execution.

--- a/docs/src/main/antora/modules/ROOT/pages/api/agentclient.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/api/agentclient.adoc
@@ -78,7 +78,7 @@ public class StandaloneExample {
 
         // 2. Configure agent options
         ClaudeAgentOptions options = ClaudeAgentOptions.builder()
-            .model("claude-sonnet-4.5")
+            .model("claude-sonnet-4-5")
             .yolo(true)
             .build();
 

--- a/docs/src/main/antora/modules/ROOT/pages/getting-started/autoconfiguration.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/getting-started/autoconfiguration.adoc
@@ -94,7 +94,7 @@ spring:
   ai:
     agents:
       claude-code:
-        model: "claude-sonnet-4.5"      # Claude model to use
+        model: "claude-sonnet-4-5"      # Claude model to use
         timeout: "PT5M"                  # Task execution timeout (5 minutes)
         yolo: true                       # Bypass permission checks (default: true)
         executable-path: "/usr/local/bin/claude"  # Optional: custom CLI path
@@ -105,7 +105,7 @@ spring:
 |Property |Default |Description
 
 |`spring.ai.agents.claude-code.model`
-|`claude-sonnet-4.5`
+|`claude-sonnet-4-5`
 |Claude model for agent tasks
 
 |`spring.ai.agents.claude-code.timeout`

--- a/docs/src/main/antora/modules/ROOT/pages/getting-started/hello-world.adoc
+++ b/docs/src/main/antora/modules/ROOT/pages/getting-started/hello-world.adoc
@@ -145,7 +145,7 @@ The fluent chain makes it easy to build up your agent request step by step.
 Spring Boot autoconfiguration handles everything automatically:
 
 * `AgentClient.Builder` bean (prototype scope)
-* Claude agent (model: claude-sonnet-4.5, yolo: true)
+* Claude agent (model: claude-sonnet-4-5, yolo: true)
 * LocalSandbox for secure execution
 
 No manual configuration required!

--- a/samples/getting-started-hello-world/README.md
+++ b/samples/getting-started-hello-world/README.md
@@ -55,7 +55,7 @@ The agent will:
 
 Spring Boot provides:
 - `AgentClient.Builder` bean (prototype scope) - automatically configured
-- Claude agent with sensible defaults (model: claude-sonnet-4.5, yolo: true)
+- Claude agent with sensible defaults (model: claude-sonnet-4-5, yolo: true)
 - LocalSandbox for secure command execution
 
 No manual configuration needed!


### PR DESCRIPTION
## Summary

Corrects the default Claude model name throughout the codebase from the incorrect `claude-sonnet-4.5` (with period) to the correct `claude-sonnet-4-5` (with hyphens).

## Changes

- **ClaudeAgentProperties.java**: Updated default model value and javadoc example
- **Documentation**: Fixed model name in autoconfiguration guide, hello-world tutorial, and API reference
- **Sample README**: Corrected model name in getting-started-hello-world documentation

## Impact

This ensures the project uses the correct Claude model identifier format, preventing potential runtime errors when the model is specified.