### PR TITLE
feat(claude-agent-sdk): add support for thinking block parsing

### DIFF
--- a/provider-sdks/claude-agent-sdk/src/main/java/org/springaicommunity/agents/claude/sdk/parsing/MessageParser.java
+++ b/provider-sdks/claude-agent-sdk/src/main/java/org/springaicommunity/agents/claude/sdk/parsing/MessageParser.java
@@ -155,6 +155,7 @@ public class MessageParser {
 				case "text" -> parseTextBlock(blockNode);
 				case "tool_use" -> parseToolUseBlock(blockNode);
 				case "tool_result" -> parseToolResultBlock(blockNode);
+				case "thinking" -> parseThinkingBlock(blockNode);
 				default -> throw new MessageParseException("Unknown content block type: " + type);
 			};
 
@@ -170,6 +171,14 @@ public class MessageParser {
 			throw new MessageParseException("Missing 'text' field in text block");
 		}
 		return TextBlock.of(text);
+	}
+
+	private ThinkingBlock parseThinkingBlock(JsonNode node) throws MessageParseException {
+		String thinking = getStringField(node, "thinking");
+		if (thinking == null) {
+			throw new MessageParseException("Missing 'thinking' field in thinking block");
+		}
+		return ThinkingBlock.of(thinking);
 	}
 
 	private ToolUseBlock parseToolUseBlock(JsonNode node) throws MessageParseException {


### PR DESCRIPTION
- Added case handling for 'thinking' block type in message parser
- Implemented parseThinkingBlock method to handle thinking content
- Added validation for missing 'thinking' field in thinking block
- Created ThinkingBlock instance from parsed thinking content