### PR TITLE
feat: support custom Anthropic API baseUrl and apiKey

### DIFF
--- a/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/ClaudeAgentModel.java
+++ b/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/ClaudeAgentModel.java
@@ -588,6 +588,21 @@ public class ClaudeAgentModel implements AgentModel, StreamingAgentModel, Iterab
 			builder.appendSystemPrompt(request.options().getSystemInstructions());
 		}
 
+		// Environment variable injection: environmentVariables, apiKey, baseUrl
+		Map<String, String> effectiveEnv = new HashMap<>();
+		if (options.getEnvironmentVariables() != null && !options.getEnvironmentVariables().isEmpty()) {
+			effectiveEnv.putAll(options.getEnvironmentVariables());
+		}
+		if (options.getApiKey() != null && !options.getApiKey().isBlank()) {
+			effectiveEnv.put("ANTHROPIC_API_KEY", options.getApiKey());
+		}
+		if (options.getBaseUrl() != null && !options.getBaseUrl().isBlank()) {
+			effectiveEnv.put("ANTHROPIC_BASE_URL", options.getBaseUrl());
+		}
+		if (!effectiveEnv.isEmpty()) {
+			builder.env(effectiveEnv);
+		}
+
 		return builder.build();
 	}
 

--- a/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/ClaudeAgentOptions.java
+++ b/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/ClaudeAgentOptions.java
@@ -150,6 +150,18 @@ public class ClaudeAgentOptions implements AgentOptions {
 	 */
 	private String appendSystemPrompt;
 
+	/**
+	 * API key for Anthropic API authentication. Translates to ANTHROPIC_API_KEY
+	 * environment variable in the CLI process.
+	 */
+	private String apiKey;
+
+	/**
+	 * Base URL for the Anthropic API (e.g., for API gateway/proxy routing). Translates to
+	 * ANTHROPIC_BASE_URL environment variable in the CLI process.
+	 */
+	private String baseUrl;
+
 	public ClaudeAgentOptions() {
 	}
 
@@ -325,6 +337,22 @@ public class ClaudeAgentOptions implements AgentOptions {
 		this.appendSystemPrompt = appendSystemPrompt;
 	}
 
+	public String getApiKey() {
+		return apiKey;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
 	@Override
 	public Map<String, Object> getExtras() {
 		return extras;
@@ -465,6 +493,16 @@ public class ClaudeAgentOptions implements AgentOptions {
 
 		public Builder appendSystemPrompt(String appendSystemPrompt) {
 			options.setAppendSystemPrompt(appendSystemPrompt);
+			return this;
+		}
+
+		public Builder apiKey(String apiKey) {
+			options.setApiKey(apiKey);
+			return this;
+		}
+
+		public Builder baseUrl(String baseUrl) {
+			options.setBaseUrl(baseUrl);
 			return this;
 		}
 

--- a/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentAutoConfiguration.java
+++ b/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentAutoConfiguration.java
@@ -100,6 +100,17 @@ public class ClaudeAgentAutoConfiguration {
 			optionsBuilder.mcpServers(mcpServers);
 		}
 
+		// API key and base URL for enterprise gateway support
+		if (properties.getApiKey() != null && !properties.getApiKey().isBlank()) {
+			optionsBuilder.apiKey(properties.getApiKey());
+		}
+		if (properties.getBaseUrl() != null && !properties.getBaseUrl().isBlank()) {
+			optionsBuilder.baseUrl(properties.getBaseUrl());
+		}
+		if (properties.getEnv() != null && !properties.getEnv().isEmpty()) {
+			optionsBuilder.environmentVariables(properties.getEnv());
+		}
+
 		ClaudeAgentOptions options = optionsBuilder.build();
 
 		ClaudeAgentModel.Builder builder = ClaudeAgentModel.builder()

--- a/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentProperties.java
+++ b/agent-models/agent-claude/src/main/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentProperties.java
@@ -18,6 +18,7 @@ package org.springaicommunity.agents.claude.autoconfigure;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +70,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *         env:
  *           CUSTOM_API_KEY: "${CUSTOM_API_KEY}"
  *           DEBUG_MODE: "true"
+ *         # Enterprise API gateway configuration
+ *         api-key: "${ANTHROPIC_API_KEY}"
+ *         base-url: "https://proxy.example.com"
  *         max-buffer-size: 2097152
  *         user: claude-runner
  * </pre>
@@ -184,6 +188,20 @@ public class ClaudeAgentProperties {
 	 * Custom environment variables for the CLI process.
 	 */
 	private Map<String, String> env;
+
+	/**
+	 * API key for Anthropic API authentication. Translates to ANTHROPIC_API_KEY
+	 * environment variable in the CLI process. Takes precedence over env map entry for
+	 * ANTHROPIC_API_KEY.
+	 */
+	private String apiKey;
+
+	/**
+	 * Base URL for the Anthropic API. Use this to route requests through an API gateway
+	 * or proxy. Translates to ANTHROPIC_BASE_URL environment variable in the CLI process.
+	 * Takes precedence over env map entry for ANTHROPIC_BASE_URL.
+	 */
+	private String baseUrl;
 
 	/**
 	 * Maximum buffer size for JSON parsing in bytes (default 1MB).
@@ -359,6 +377,22 @@ public class ClaudeAgentProperties {
 		this.env = env;
 	}
 
+	public String getApiKey() {
+		return apiKey;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
 	public Integer getMaxBufferSize() {
 		return maxBufferSize;
 	}
@@ -460,9 +494,19 @@ public class ClaudeAgentProperties {
 			builder.extraArgs(extraArgs);
 		}
 
-		// Environment variables
+		// Environment variables: merge env map with explicit apiKey/baseUrl
+		Map<String, String> effectiveEnv = new HashMap<>();
 		if (env != null && !env.isEmpty()) {
-			builder.env(env);
+			effectiveEnv.putAll(env);
+		}
+		if (apiKey != null && !apiKey.isBlank()) {
+			effectiveEnv.put("ANTHROPIC_API_KEY", apiKey);
+		}
+		if (baseUrl != null && !baseUrl.isBlank()) {
+			effectiveEnv.put("ANTHROPIC_BASE_URL", baseUrl);
+		}
+		if (!effectiveEnv.isEmpty()) {
+			builder.env(effectiveEnv);
 		}
 
 		// Buffer size protection

--- a/agent-models/agent-claude/src/test/java/org/springaicommunity/agents/claude/ClaudeAgentModelTest.java
+++ b/agent-models/agent-claude/src/test/java/org/springaicommunity/agents/claude/ClaudeAgentModelTest.java
@@ -27,10 +27,13 @@ import org.springaicommunity.claude.agent.sdk.types.control.HookOutput;
 import org.springaicommunity.agents.model.AgentModel;
 import org.springaicommunity.agents.model.IterableAgentModel;
 import org.springaicommunity.agents.model.StreamingAgentModel;
+import org.springaicommunity.agents.model.AgentTaskRequest;
+import org.springaicommunity.claude.agent.sdk.transport.CLIOptions;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -439,6 +442,98 @@ class ClaudeAgentModelTest {
 				.build();
 
 			assertThat(model).isNotNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Environment Variable Injection Tests")
+	class EnvInjectionTests {
+
+		@Test
+		@DisplayName("apiKey translates to ANTHROPIC_API_KEY in CLI env")
+		void apiKeyTranslatesToEnv() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder()
+				.model("claude-sonnet-4-5")
+				.apiKey("sk-test-key")
+				.build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).containsEntry("ANTHROPIC_API_KEY", "sk-test-key");
+		}
+
+		@Test
+		@DisplayName("baseUrl translates to ANTHROPIC_BASE_URL in CLI env")
+		void baseUrlTranslatesToEnv() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder()
+				.model("claude-sonnet-4-5")
+				.baseUrl("https://proxy.example.com")
+				.build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).containsEntry("ANTHROPIC_BASE_URL", "https://proxy.example.com");
+		}
+
+		@Test
+		@DisplayName("apiKey overrides environmentVariables ANTHROPIC_API_KEY")
+		void apiKeyOverridesEnvironmentVariables() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder()
+				.model("claude-sonnet-4-5")
+				.environmentVariables(Map.of("ANTHROPIC_API_KEY", "env-var-key"))
+				.apiKey("explicit-key")
+				.build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).containsEntry("ANTHROPIC_API_KEY", "explicit-key");
+		}
+
+		@Test
+		@DisplayName("environmentVariables flows through to CLI env")
+		void environmentVariablesFlowThrough() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder()
+				.model("claude-sonnet-4-5")
+				.environmentVariables(Map.of("CUSTOM_VAR", "custom-value"))
+				.build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).containsEntry("CUSTOM_VAR", "custom-value");
+		}
+
+		@Test
+		@DisplayName("apiKey and baseUrl coexist with environmentVariables")
+		void allEnvSourcesCoexist() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder()
+				.model("claude-sonnet-4-5")
+				.environmentVariables(Map.of("CUSTOM_VAR", "value"))
+				.apiKey("sk-test")
+				.baseUrl("https://proxy.example.com")
+				.build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).containsEntry("CUSTOM_VAR", "value");
+			assertThat(cliOptions.getEnv()).containsEntry("ANTHROPIC_API_KEY", "sk-test");
+			assertThat(cliOptions.getEnv()).containsEntry("ANTHROPIC_BASE_URL", "https://proxy.example.com");
+		}
+
+		@Test
+		@DisplayName("No env injection when all fields are null")
+		void noEnvInjectionWhenNull() {
+			ClaudeAgentOptions options = ClaudeAgentOptions.builder().model("claude-sonnet-4-5").build();
+			model = ClaudeAgentModel.builder().defaultOptions(options).build();
+
+			CLIOptions cliOptions = model.buildCLIOptions(new AgentTaskRequest("test", TEST_WORKING_DIR, options));
+
+			assertThat(cliOptions.getEnv()).isNullOrEmpty();
 		}
 
 	}

--- a/agent-models/agent-claude/src/test/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentPropertiesTest.java
+++ b/agent-models/agent-claude/src/test/java/org/springaicommunity/agents/claude/autoconfigure/ClaudeAgentPropertiesTest.java
@@ -53,11 +53,12 @@ class ClaudeAgentPropertiesTest {
 			assertThat(properties.getPermissionMode()).isNull();
 			assertThat(properties.getJsonSchema()).isNull();
 			assertThat(properties.getMaxTokens()).isNull();
-			// New budget control and fallback model defaults
 			assertThat(properties.getMaxTurns()).isNull();
 			assertThat(properties.getMaxBudgetUsd()).isNull();
 			assertThat(properties.getFallbackModel()).isNull();
 			assertThat(properties.getAppendSystemPrompt()).isNull();
+			assertThat(properties.getApiKey()).isNull();
+			assertThat(properties.getBaseUrl()).isNull();
 		}
 
 	}
@@ -157,7 +158,6 @@ class ClaudeAgentPropertiesTest {
 		void shouldUseBypassWhenYoloIsTrue() {
 			ClaudeAgentProperties properties = new ClaudeAgentProperties();
 			properties.setYolo(true);
-			// No explicit permission mode
 
 			CLIOptions options = properties.buildCLIOptions();
 			assertThat(options.getPermissionMode()).isEqualTo(PermissionMode.BYPASS_PERMISSIONS);
@@ -313,6 +313,89 @@ class ClaudeAgentPropertiesTest {
 	}
 
 	@Nested
+	@DisplayName("API Key and Base URL Tests")
+	class ApiKeyBaseUrlTests {
+
+		@Test
+		@DisplayName("Should set apiKey as ANTHROPIC_API_KEY env var")
+		void shouldSetApiKeyAsEnvVar() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setApiKey("sk-test-key");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_API_KEY", "sk-test-key");
+		}
+
+		@Test
+		@DisplayName("Should set baseUrl as ANTHROPIC_BASE_URL env var")
+		void shouldSetBaseUrlAsEnvVar() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setBaseUrl("https://proxy.example.com");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_BASE_URL", "https://proxy.example.com");
+		}
+
+		@Test
+		@DisplayName("Explicit apiKey should override env map ANTHROPIC_API_KEY")
+		void apiKeyOverridesEnvMap() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setEnv(Map.of("ANTHROPIC_API_KEY", "env-map-key"));
+			properties.setApiKey("explicit-key");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_API_KEY", "explicit-key");
+		}
+
+		@Test
+		@DisplayName("Explicit baseUrl should override env map ANTHROPIC_BASE_URL")
+		void baseUrlOverridesEnvMap() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setEnv(Map.of("ANTHROPIC_BASE_URL", "https://env-url.com"));
+			properties.setBaseUrl("https://explicit-url.com");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_BASE_URL", "https://explicit-url.com");
+		}
+
+		@Test
+		@DisplayName("Should work alongside other env vars")
+		void shouldWorkAlongsideOtherEnvVars() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setEnv(Map.of("CUSTOM_VAR", "custom-value"));
+			properties.setApiKey("sk-test");
+			properties.setBaseUrl("https://proxy.example.com");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).containsEntry("CUSTOM_VAR", "custom-value");
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_API_KEY", "sk-test");
+			assertThat(options.getEnv()).containsEntry("ANTHROPIC_BASE_URL", "https://proxy.example.com");
+		}
+
+		@Test
+		@DisplayName("Null apiKey and baseUrl should not add env entries")
+		void nullValuesShouldNotAddEnvEntries() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).isNullOrEmpty();
+		}
+
+		@Test
+		@DisplayName("Blank apiKey and baseUrl should not add env entries")
+		void blankValuesShouldNotAddEnvEntries() {
+			ClaudeAgentProperties properties = new ClaudeAgentProperties();
+			properties.setApiKey("   ");
+			properties.setBaseUrl("   ");
+
+			CLIOptions options = properties.buildCLIOptions();
+			assertThat(options.getEnv()).doesNotContainKey("ANTHROPIC_API_KEY");
+			assertThat(options.getEnv()).doesNotContainKey("ANTHROPIC_BASE_URL");
+		}
+
+	}
+
+	@Nested
 	@DisplayName("Build CLI Options Tests")
 	class BuildCLIOptionsTests {
 
@@ -329,7 +412,6 @@ class ClaudeAgentPropertiesTest {
 			properties.setDisallowedTools(List.of("WebSearch"));
 			properties.setPermissionMode("acceptEdits");
 			properties.setJsonSchema(Map.of("type", "object"));
-			// New budget control and fallback model properties
 			properties.setMaxTurns(10);
 			properties.setMaxBudgetUsd(0.50);
 			properties.setFallbackModel("claude-haiku-3-5-20241022");
@@ -346,7 +428,6 @@ class ClaudeAgentPropertiesTest {
 			assertThat(options.getDisallowedTools()).containsExactly("WebSearch");
 			assertThat(options.getPermissionMode()).isEqualTo(PermissionMode.ACCEPT_EDITS);
 			assertThat(options.getJsonSchema()).isEqualTo(Map.of("type", "object"));
-			// New budget control and fallback model assertions
 			assertThat(options.getMaxTurns()).isEqualTo(10);
 			assertThat(options.getMaxBudgetUsd()).isEqualTo(0.50);
 			assertThat(options.getFallbackModel()).isEqualTo("claude-haiku-3-5-20241022");


### PR DESCRIPTION
## Summary

- Add `agent-client.claude.api-key` and `agent-client.claude.base-url` configuration properties for enterprise users to route requests through internal API gateways
- These properties translate to `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` environment variables in the CLI process, with explicit properties taking precedence over the `env` map
- Fix `ClaudeAgentOptions.environmentVariables` not being propagated to the CLI process (dead code)

Closes #25

## Changes

| File | Change |
|------|--------|
| `ClaudeAgentProperties.java` | Add `apiKey`/`baseUrl` fields, update `buildCLIOptions()` to merge into env map |
| `ClaudeAgentOptions.java` | Add `apiKey`/`baseUrl` fields and builder methods |
| `ClaudeAgentModel.java` | Translate `environmentVariables`/`apiKey`/`baseUrl` into `CLIOptions.env` |
| `ClaudeAgentAutoConfiguration.java` | Pass `apiKey`/`baseUrl`/`env` from properties to options builder |
| Tests | 13 new tests covering defaults, setting, precedence, and coexistence |

## Configuration Example

```yaml
agent-client:
  claude:
    api-key: "${ANTHROPIC_API_KEY}"
    base-url: "https://proxy.example.com"
```

## Precedence

Explicit `apiKey`/`baseUrl` properties > `env` map entries > system `ANTHROPIC_API_KEY`

## Test Plan

- [x] Unit tests: `ClaudeAgentPropertiesTest` (7 new tests), `ClaudeAgentModelTest` (6 new tests)
- [x] Integration test verified against third-party Anthropic-compatible endpoint
- [x] Formatting clean: `spring-javaformat:validate` passes
- [x] All 65 existing tests pass